### PR TITLE
pass in the default zinnia scheme, if available, to shortened url

### DIFF
--- a/zinnia_bitly/__init__.py
+++ b/zinnia_bitly/__init__.py
@@ -18,5 +18,6 @@ def backend(entry):
     """
     Bit.ly URL shortener backend for Zinnia.
     """
-    bittle = Bittle.objects.bitlify(entry)
+    scheme = getattr(settings, 'ZINNIA_PROTOCOL', 'http')
+    bittle = Bittle.objects.bitlify(entry, scheme=scheme)
     return bittle.shortUrl


### PR DESCRIPTION
This will allow you to use https url schemes, if desired.
